### PR TITLE
Fix Mac Slicon Problems

### DIFF
--- a/rvcgui.py
+++ b/rvcgui.py
@@ -414,7 +414,7 @@ def on_button_click():
 
 def browse_file():
     filepath = filedialog.askopenfilename (
-        filetypes=[("Audio Files", "*.wav;*.mp3")])
+        filetypes=[("Audio Files", ["*.mp3","*.wav"])])
     filepath = os.path.normpath(filepath)  # Normalize file path
     input_audio_entry.delete(0, tk.END)
     input_audio_entry.insert(0, filepath)

--- a/vc_infer_pipeline.py
+++ b/vc_infer_pipeline.py
@@ -330,7 +330,7 @@ class VC(object):
             pitch = pitch[:p_len]
             pitchf = pitchf[:p_len]
             pitch = torch.tensor(pitch, device=self.device).unsqueeze(0).long()
-            pitchf = torch.tensor(pitchf, device=self.device).unsqueeze(0).float()
+            pitchf = torch.tensor(pitchf, device=self.device, dtype=torch.float32).unsqueeze(0).float()
         t2 = ttime()
         times[1] += t2 - t1
         for t in opt_ts:


### PR DESCRIPTION
* Fix mp3, wav selection.
* Fix float64 error on apple silicons.

Do not forget to do the following on Apple silicon macs:

`pip install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu`


`export PYTORCH_ENABLE_MPS_FALLBACK=1`